### PR TITLE
Added the ability to specify a base URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ How to setup :
   * make sure it's only accessible by power users
   * enjoy !
 
+If you want to use a different path :
+
+	var basePath = /my/custom/path/to/spodadmin/
+	spadm.AdminStyle.BASE_URL = basePath;
+	spadm.Admin.handler(basePath);

--- a/spadm/Admin.hx
+++ b/spadm/Admin.hx
@@ -1007,13 +1007,9 @@ class Admin {
 		return hasSyncAction;
 	}
 
-	public function process( ?url : Array<String> ) {
+	public function process( ?url : Array<String>, ?baseUrl = "/db/" ) {
 		if( url == null ) {
-			url = neko.Web.getURI().split("/");
-			url.shift(); // empty : url starts with /
-			url.shift(); // "admin"
-			if( url[0] == "index.n" )
-				url.shift();
+			url = neko.Web.getURI().substr(baseUrl.length).split("/");
 		}
 		if( url.length == 0 ) url.push("");
 		var params = neko.Web.getParams();
@@ -1060,10 +1056,10 @@ class Admin {
 		neko.Web.logMessage("[DBADM] "+neko.Web.getHostName()+" "+Date.now().toString()+" "+neko.Web.getClientIP()+" - "+msg);
 	}
 
-	public static function handler() {
+	public static function handler( ?baseUrl:String ) {
 		Manager.initialize(); // make sure it's been done
 		try {
-			new Admin().process();
+			new Admin().process(baseUrl);
 		} catch( e : Dynamic ) {
 			// rollback in case of multiple delete/update - no effect on DB struct changes
 			// since they are done outside of transaction


### PR DESCRIPTION
Hi Nicolas, thanks for the great lib!  I am trying to set up a general website admin, with

```
/admin/       # the main site
/admin/db/    # spodadmin
```

I'm pretty sure this patch should be backwards compatible with the instructions given in the README, though the previous code was more lenient and would let you choose any top-level subdirectory, rather than only "db/".

If you choose not to accept it I can subclass, but I thought the extra flexibility might be useful for others also.

....

Previously it assumed that you were in a top level directory, and just removed the first "/$something" from the path.

Now you must specify the base URL, and we just substitute it out.

If you don't specify a baseURL, "/db/" is assumed.
